### PR TITLE
デプロイエラー修正

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,10 +47,10 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: build page
         run: pnpm build
-      - uses: actions/upload-pages-artifact@v1
-        if: ${{ github.ref == 'refs/heads/main' || github.event_name == 'schedule' }}
+      - uses: actions/upload-pages-artifact@v3
+        # if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/deploy-test' || github.event_name == 'schedule' }}
         with:
-          path: build
+          path: build/
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
> Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

の修正